### PR TITLE
Reformat for Terraform Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Modular Internal Load Balancer for GCE using forwarding rules.
 
 ```ruby
 module "gce-ilb" {
-  source         = "github.com/GoogleCloudPlatform/terraform-google-lb-internal"
+  source         = "GoogleCloudPlatform/lb-internal/google"
   region         = "${var.region}"
   name           = "group2-ilb"
   ports          = ["${module.mig2.service_port}"]
@@ -20,28 +20,8 @@ module "gce-ilb" {
 }
 ```
 
-### Input variables
-
-- `region` (optional): Region for cloud resources. Default is `us-central1`.
-- `network` (optional): Name of the network to create resources in. Default is `default`.
-- `name` (required): Name for the forwarding rule and prefix for supporting resources.
-- `backends` (optional): List of backends, should be a map of key-value pairs for each backend, mush have the 'group' key.
-- `session_affinity`(optional): The session affinity for the backends example: NONE, CLIENT_IP. Default is `NONE`.
-- `ports` (required): List of ports range to forward to backend services. Max is 5.
-- `health_port` (requierd): Port to perform health checks on.
-- `source_tags`: (required): List of source tags for traffic between the internal load balancer.
-- `target_tags`: (required): List of target tags for traffic between the internal load balancer.
-- `ip_address` (optional) IP address of the internal load balancer, if empty one will be assigned. Default is empty.
-
-### Output variables
-
-- `ip_address`: The internal IP assigned to the regional fowarding rule.
 
 ## Resources created
-
-**Figure 1.** *diagram of terraform resources*
-
-![architecture diagram](./diagram.png)
 
 - [`google_compute_forwarding_rule.default`](https://www.terraform.io/docs/providers/google/r/compute_forwarding_rule.html): The internal regional forwarding rule.
 - [`google_compute_region_backend_service.default`](https://www.terraform.io/docs/providers/google/r/compute_region_backend_service.html): The backend service registered to the given `instance_group`.


### PR DESCRIPTION
Hi team,

renamed the path of the source to the module registry instead of the GitHub repo

removed variables because all variable information is sourced from the variable and output files.

removed figure diagram because the Terraform Registry cannot render the image

If you can merge this into master and then add another release/tag so that the module registry will update. After that we'll be able to verify this module.

Thanks
Chris